### PR TITLE
require riot on each tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,6 @@ module.exports = {
     path: __dirname + '/public',
     filename: 'bundle.js'
   },
-  plugins: [
-    new webpack.ProvidePlugin({
-      riot: 'riot'
-    })
-  ],
   module: {
     preLoaders: [
       { test: /\.tag$/, exclude: /node_modules/, loader: 'riotjs-loader', query: { type: 'none' } }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var riot = require('riot'),
-    loaderUtils = require('loader-utils');
+    loaderUtils = require('loader-utils'),
+    REQUIRE_RIOT = 'var riot = require("riot");\n\n';
 
 
 module.exports = function (source) {
@@ -32,7 +33,7 @@ module.exports = function (source) {
   });
 
   try {
-    return riot.compile(content, options);
+    return REQUIRE_RIOT + riot.compile(content, options);
   } catch (e) {
     throw new Error(e);
   }


### PR DESCRIPTION
putting require to riot in each tag eliminates the need to use RequirePlugin.
