### PR TITLE
compile with full filename

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ module.exports = function (source) {
   });
 
   try {
-    return riot.compile(content, options);
+    return riot.compile(content, options, this.resourcePath);
   } catch (e) {
     throw new Error(e);
   }


### PR DESCRIPTION
This make it compile `<script src="./foo.js"></script>`

See also:
[https://github.com/riot/riot/issues/507#issuecomment-158966012](https://github.com/riot/riot/issues/507#issuecomment-158966012)
[http://webpack.github.io/docs/loaders.html#resourcepath](http://webpack.github.io/docs/loaders.html#resourcepath)
