### PR TITLE
Migrate to riot-compiler and add support for html only compilation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,17 @@ require('./name.tag');
 </name>
 ```
 
+## Template compilation only
+Using the property htmlOnly with riotjs-loader permit to only compile the html template.
+
+### Example
+```javascript
+var riot = require('riot');
+var myTemplate = require('riotjs?htmlOnly!./monTemplate.html')
+
+riot.tag('demo', myTemplate);
+```
+
 ## development
 
 ```bash

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var riot = require('riot'),
+var riot = require('riot-compiler'),
     loaderUtils = require('loader-utils');
 
 
@@ -6,11 +6,6 @@ module.exports = function (source) {
 
   var content = source;
   var options = loaderUtils.parseQuery(this.query);
-
-  if (options.brackets) {
-    riot.settings.brackets = options.brackets;
-    delete options.brackets;
-  }
 
   if (this.cacheable) this.cacheable();
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,9 @@ module.exports = function (source) {
   var content = source;
   var options = loaderUtils.parseQuery(this.query);
 
+  var htmlOnly = options.htmlOnly;
+  delete options.htmlOnly;
+
   if (this.cacheable) this.cacheable();
 
   Object.keys(options).forEach(function(key) {
@@ -27,7 +30,11 @@ module.exports = function (source) {
   });
 
   try {
-    return riot.compile(content, options);
+    if (!htmlOnly) {
+      return riot.compile(content, options);
+    } else {
+      return riot.html(content, options);
+    }
   } catch (e) {
     throw new Error(e);
   }

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   },
   "homepage": "https://github.com/esnunes/riotjs-loader",
   "dependencies": {
-    "loader-utils": "^0.2.6"
+    "loader-utils": "^0.2.6",
+    "riot-compiler": "^2.3.22"
   },
   "peerDependencies": {
-    "riot": "^2.0.5",
     "webpack": "^1.5.3"
   }
 }


### PR DESCRIPTION
The goal is to permit the use of : http://riotjs.com/api/#manual-construction
In webpack without loosing advantages of riot-compiler.
