### PR TITLE
Add htmlOnly option to enable compilling only html templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ require('./name.tag');
   <h1>{ opts.last }, { opts.first }</h1>
 </name>
 ```
+## Template compilation only
+Using the property htmlOnly with riotjs-loader permit to only compile the html template.
+
+### Example
+```javascript
+var riot = require('riot');
+var myTemplate = require('riotjs?htmlOnly!./myTemplate.html');
+
+riot.tag('demo', myTemplate);
+```
 
 ## development
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,9 @@ module.exports = function (source) {
   var content = source;
   var options = loaderUtils.parseQuery(this.query);
 
+  var htmlOnly = options.htmlOnly;
+  delete options.htmlOnly;
+
   if (this.cacheable) this.cacheable();
 
   Object.keys(options).forEach(function(key) {
@@ -27,7 +30,11 @@ module.exports = function (source) {
   });
 
   try {
-    return riot.compile(content, options);
+    if(htmlOnly) {
+      return riot.html(content, options);
+    } else {
+      return riot.compile(content, options);
+    }
   } catch (e) {
     throw new Error(e);
   }


### PR DESCRIPTION
Added to permit using custom tags on riot without loosing advantages of riot templates.
http://riotjs.com/api/#manual-construction
