### PR TITLE
Throw Error objects as-is

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,10 @@ module.exports = function (source) {
   try {
     return riot.compile(content, options);
   } catch (e) {
-    throw new Error(e);
+    if (e instanceof Error) {
+      throw e;
+    } else {
+      throw new Error(e);
+    }
   }
 };


### PR DESCRIPTION
I'm assuming that the old approach to this was in place to deal with strings being thrown - however, when feeding an Error object into an Error constructor, it just destroys the stacktrace. This change will make it only create a new Error object if the error thrown wasn't already one.
